### PR TITLE
Add upgrade unit tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -93,11 +93,11 @@ Runs tests on a specific, already deployed contract.
 
 ### Unit tests
 
-[] Apply a passed proposal
+[x] Apply a passed proposal
 
 Test that a proposal marked as passed is correctly applied, including the appropriate contract upgrade.
 
-[] Apply already applied proposal
+[x] Apply already applied proposal
 
 Ensure the contract rejects applying a proposal that has already been applied.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -101,11 +101,11 @@ Test that a proposal marked as passed is correctly applied, including the approp
 
 Ensure the contract rejects applying a proposal that has already been applied.
 
-[] Apply failed proposal
+[x] Apply failed proposal
 
 Ensure the contract rejects applying a proposal that did not pass.
 
-[] Apply non-existent proposal
+[x] Apply non-existent proposal
 
 Ensure the contract rejects applying a proposal that does not exist.
 

--- a/tests/lib.cairo
+++ b/tests/lib.cairo
@@ -2,4 +2,5 @@ mod basic;
 mod test_treasury;
 mod proposals_tests;
 mod airdrop_tests;
+mod upgrades_tests;
 mod setup;

--- a/tests/upgrades_tests.cairo
+++ b/tests/upgrades_tests.cairo
@@ -11,8 +11,7 @@ use konoha::upgrades::IUpgradesDispatcher;
 use konoha::upgrades::IUpgradesDispatcherTrait;
 use konoha::constants;
 
-use snforge_std as snf;
-use snforge_std::{CheatTarget, ContractClassTrait};
+use snforge_std::{CheatTarget, ContractClassTrait, prank, CheatSpan, get_class_hash};
 
 use super::setup::{admin_addr, deploy_governance, deploy_and_distribute_gov_tokens,};
 
@@ -23,27 +22,23 @@ fn test_apply_a_passed_proposal() {
     let gov_contract = deploy_governance(token_contract.contract_address);
     let gov_contract_addr = gov_contract.contract_address;
     let dispatcher = IProposalsDispatcher { contract_address: gov_contract_addr };
-    let class_hash: felt252 = snf::get_class_hash(token_contract.contract_address)
-        .try_into()
-        .unwrap();
+    let class_hash: felt252 = get_class_hash(token_contract.contract_address).try_into().unwrap();
 
-    assert!(
-        snf::get_class_hash(gov_contract_addr).try_into().unwrap() != class_hash,
-        "Wrong initial class hash"
+    prank(
+        CheatTarget::One(gov_contract_addr),
+        admin_addr.try_into().unwrap(),
+        CheatSpan::TargetCalls(3)
     );
-
-    snf::start_prank(CheatTarget::One(gov_contract_addr), admin_addr.try_into().unwrap());
     let prop_id = dispatcher.submit_proposal(class_hash, 1); // class hash update
     dispatcher.vote(prop_id, 1);
 
     IUpgradesDispatcher { contract_address: gov_contract_addr }.apply_passed_proposal(prop_id);
 
     assert_eq!(
-        snf::get_class_hash(gov_contract_addr).try_into().unwrap(),
+        get_class_hash(gov_contract_addr).try_into().unwrap(),
         class_hash,
         "Worng classhash after upgrade"
     );
-    snf::stop_prank(CheatTarget::One(gov_contract_addr));
 }
 
 #[test]
@@ -54,7 +49,11 @@ fn test_apply_an_already_passed_proposal() {
     let gov_contract_addr = gov_contract.contract_address;
     let dispatcher = IProposalsDispatcher { contract_address: gov_contract_addr };
 
-    snf::start_prank(CheatTarget::One(gov_contract_addr), admin_addr.try_into().unwrap());
+    prank(
+        CheatTarget::One(gov_contract_addr),
+        admin_addr.try_into().unwrap(),
+        CheatSpan::TargetCalls(4)
+    );
     let prop_id = dispatcher.submit_proposal(42, 4); // no op
     dispatcher.vote(prop_id, 1);
 
@@ -62,7 +61,6 @@ fn test_apply_an_already_passed_proposal() {
 
     // try to reapply the same proposal
     IUpgradesDispatcher { contract_address: gov_contract_addr }.apply_passed_proposal(prop_id);
-    snf::stop_prank(CheatTarget::One(gov_contract_addr));
 }
 
 #[test]
@@ -73,7 +71,11 @@ fn test_apply_a_failed_proposal() {
     let gov_contract_addr = gov_contract.contract_address;
     let dispatcher = IProposalsDispatcher { contract_address: gov_contract_addr };
 
-    snf::start_prank(CheatTarget::One(gov_contract_addr), admin_addr.try_into().unwrap());
+    prank(
+        CheatTarget::One(gov_contract_addr),
+        admin_addr.try_into().unwrap(),
+        CheatSpan::TargetCalls(3)
+    );
     let prop_id = dispatcher.submit_proposal(42, 4); // no op
     dispatcher.vote(prop_id, 2);
 
@@ -87,28 +89,32 @@ fn test_apply_a_non_existent_proposal() {
     let gov_contract = deploy_governance(token_contract.contract_address);
     let gov_contract_addr = gov_contract.contract_address;
     let prop_id = 4269;
-    snf::start_prank(CheatTarget::One(gov_contract_addr), admin_addr.try_into().unwrap());
+    prank(
+        CheatTarget::One(gov_contract_addr),
+        admin_addr.try_into().unwrap(),
+        CheatSpan::TargetCalls(1)
+    );
 
     IUpgradesDispatcher { contract_address: gov_contract_addr }.apply_passed_proposal(prop_id);
 }
+// #[test]
+// fn test_successfull_contract_upgrade() {
+//     assert_eq!(1, 0, "TODO");
+// }
+// 
+// #[test]
+// fn test_upgrade_with_custom_proposal_execution() {
+//     assert_eq!(1, 0, "TODO");
+// }
+// 
+// #[test]
+// fn test_multiple_contract_upgrades() {
+//     assert_eq!(1, 0, "TODO");
+// }
+// 
+// #[test]
+// fn test_event_with_failed_upgrade_attempts() {
+//     assert_eq!(1, 0, "TODO");
+// }
 
 
-#[test]
-fn test_successfull_contract_upgrade() {
-    assert_eq!(1, 0, "TODO");
-}
-
-#[test]
-fn test_upgrade_with_custom_proposal_execution() {
-    assert_eq!(1, 0, "TODO");
-}
-
-#[test]
-fn test_multiple_contract_upgrades() {
-    assert_eq!(1, 0, "TODO");
-}
-
-#[test]
-fn test_event_with_failed_upgrade_attempts() {
-    assert_eq!(1, 0, "TODO");
-}

--- a/tests/upgrades_tests.cairo
+++ b/tests/upgrades_tests.cairo
@@ -1,0 +1,99 @@
+use traits::Into;
+use traits::TryInto;
+
+use starknet::{ContractAddress, storage_access::storage_address_from_base};
+
+use konoha::contract::IGovernanceDispatcher;
+use konoha::contract::IGovernanceDispatcherTrait;
+use konoha::proposals::IProposalsDispatcher;
+use konoha::proposals::IProposalsDispatcherTrait;
+use konoha::upgrades::IUpgradesDispatcher;
+use konoha::upgrades::IUpgradesDispatcherTrait;
+use konoha::constants;
+
+use snforge_std as snf;
+use snforge_std::{CheatTarget, ContractClassTrait};
+
+use super::setup::{admin_addr, deploy_governance, deploy_and_distribute_gov_tokens,};
+
+
+#[test]
+fn test_apply_a_passed_proposal() {
+    let token_contract = deploy_and_distribute_gov_tokens(admin_addr.try_into().unwrap());
+    let gov_contract = deploy_governance(token_contract.contract_address);
+    let gov_contract_addr = gov_contract.contract_address;
+    let dispatcher = IProposalsDispatcher { contract_address: gov_contract_addr };
+    let class_hash: felt252 = snf::get_class_hash(token_contract.contract_address)
+        .try_into()
+        .unwrap();
+
+    assert!(
+        snf::get_class_hash(gov_contract_addr).try_into().unwrap() != class_hash,
+        "Wrong initial class hash"
+    );
+
+    snf::start_prank(CheatTarget::One(gov_contract_addr), admin_addr.try_into().unwrap());
+    let prop_id = dispatcher.submit_proposal(class_hash, 1); // class hash update
+    dispatcher.vote(prop_id, 1);
+
+    IUpgradesDispatcher { contract_address: gov_contract_addr }.apply_passed_proposal(prop_id);
+
+    assert_eq!(
+        snf::get_class_hash(gov_contract_addr).try_into().unwrap(),
+        class_hash,
+        "Worng classhash after upgrade"
+    );
+    snf::stop_prank(CheatTarget::One(gov_contract_addr));
+}
+
+#[test]
+#[should_panic(expected: ('Proposal already applied',))]
+fn test_apply_an_already_passed_proposal() {
+    let token_contract = deploy_and_distribute_gov_tokens(admin_addr.try_into().unwrap());
+    let gov_contract = deploy_governance(token_contract.contract_address);
+    let gov_contract_addr = gov_contract.contract_address;
+    let dispatcher = IProposalsDispatcher { contract_address: gov_contract_addr };
+
+    snf::start_prank(CheatTarget::One(gov_contract_addr), admin_addr.try_into().unwrap());
+    let prop_id = dispatcher.submit_proposal(42, 4); // no op
+    dispatcher.vote(prop_id, 1);
+
+    IUpgradesDispatcher { contract_address: gov_contract_addr }.apply_passed_proposal(prop_id);
+
+    // try to reapply the same proposal
+    IUpgradesDispatcher { contract_address: gov_contract_addr }.apply_passed_proposal(prop_id);
+    snf::stop_prank(CheatTarget::One(gov_contract_addr));
+}
+
+#[test]
+#[should_panic]
+fn test_apply_a_failed_proposal() {
+    assert_eq!(1, 1, "TODO");
+}
+
+#[test]
+#[should_panic]
+fn test_apply_a_non_existent_proposal() {
+    assert_eq!(1, 1, "TODO");
+}
+
+
+#[test]
+fn test_successfull_contract_upgrade() {
+    assert_eq!(1, 0, "TODO");
+}
+
+#[test]
+fn test_upgrade_with_custom_proposal_execution() {
+    assert_eq!(1, 0, "TODO");
+}
+
+#[test]
+fn test_multiple_contract_upgrades() {
+    assert_eq!(1, 0, "TODO");
+}
+
+#[test]
+fn test_event_with_failed_upgrade_attempts() {
+    assert_eq!(1, 0, "TODO");
+}

--- a/tests/upgrades_tests.cairo
+++ b/tests/upgrades_tests.cairo
@@ -66,15 +66,30 @@ fn test_apply_an_already_passed_proposal() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected: ('prop not passed',))]
 fn test_apply_a_failed_proposal() {
-    assert_eq!(1, 1, "TODO");
+    let token_contract = deploy_and_distribute_gov_tokens(admin_addr.try_into().unwrap());
+    let gov_contract = deploy_governance(token_contract.contract_address);
+    let gov_contract_addr = gov_contract.contract_address;
+    let dispatcher = IProposalsDispatcher { contract_address: gov_contract_addr };
+
+    snf::start_prank(CheatTarget::One(gov_contract_addr), admin_addr.try_into().unwrap());
+    let prop_id = dispatcher.submit_proposal(42, 4); // no op
+    dispatcher.vote(prop_id, 2);
+
+    IUpgradesDispatcher { contract_address: gov_contract_addr }.apply_passed_proposal(prop_id);
 }
 
 #[test]
 #[should_panic]
 fn test_apply_a_non_existent_proposal() {
-    assert_eq!(1, 1, "TODO");
+    let token_contract = deploy_and_distribute_gov_tokens(admin_addr.try_into().unwrap());
+    let gov_contract = deploy_governance(token_contract.contract_address);
+    let gov_contract_addr = gov_contract.contract_address;
+    let prop_id = 4269;
+    snf::start_prank(CheatTarget::One(gov_contract_addr), admin_addr.try_into().unwrap());
+
+    IUpgradesDispatcher { contract_address: gov_contract_addr }.apply_passed_proposal(prop_id);
 }
 
 


### PR DESCRIPTION
Closes #92 

The following unit tests have been added for the following scenarios:
- Apply a passed proposal: Ensure a proposal marked as passed is correctly applied.
- Apply already applied proposal: Ensure the contract rejects reapplying a proposal that has already been applied.
- Apply failed proposal: Ensure the contract rejects applying a proposal that did not pass.
- Apply non-existent proposal: Ensure the contract rejects applying a proposal that does not exist.