### PR TITLE
Add / Remove liquidity from Nostra Pools

### DIFF
--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -1,6 +1,7 @@
 mod airdrop;
 mod treasury_types {
     mod carmine;
+    mod nostra;
 }
 mod constants;
 mod contract;

--- a/src/treasury_types/nostra.cairo
+++ b/src/treasury_types/nostra.cairo
@@ -1,0 +1,37 @@
+use starknet::ContractAddress;
+
+#[starknet::interface]
+trait INostraRouter<TContractState> {
+    fn add_liquidity(
+        ref self: TContractState,
+        pair: ContractAddress,
+        amount_0_desired: u256,
+        amount_1_desired: u256,
+        amount_0_min: u256,
+        amount_1_min: u256,
+        to: ContractAddress,
+        deadline: u64
+    ) -> (u256, u256, u256);
+    fn remove_liquidity(
+        ref self: TContractState,
+        pair: ContractAddress,
+        liquidity: u256,
+        amount_0_min: u256,
+        amount_1_min: u256,
+        to: ContractAddress,
+        deadline: u64
+    ) -> (u256, u256);
+}
+
+#[derive(Copy, Drop, Serde)]
+enum NostraPair {
+    STRK_ETH,
+}
+
+#[starknet::interface]
+trait INostraPair<TContractState> {
+    fn token_0(self: @TContractState) -> ContractAddress;
+    fn token_1(self: @TContractState) -> ContractAddress;
+    fn balance_of(self: @TContractState, account: ContractAddress) -> u256;
+    fn approve(ref self: TContractState, spender: ContractAddress, amount: u256);
+}

--- a/src/treasury_types/nostra.cairo
+++ b/src/treasury_types/nostra.cairo
@@ -26,6 +26,11 @@ trait INostraRouter<TContractState> {
 #[derive(Copy, Drop, Serde)]
 enum NostraPair {
     STRK_ETH,
+    STRK_USDC,
+    USDC_USDT,
+    ETH_USDC,
+    ETH_USDT,
+    WBTC_ETH,
 }
 
 #[starknet::interface]

--- a/src/treasury_types/nostra.cairo
+++ b/src/treasury_types/nostra.cairo
@@ -23,16 +23,6 @@ trait INostraRouter<TContractState> {
     ) -> (u256, u256);
 }
 
-#[derive(Copy, Drop, Serde)]
-enum NostraPair {
-    STRK_ETH,
-    STRK_USDC,
-    USDC_USDT,
-    ETH_USDC,
-    ETH_USDT,
-    WBTC_ETH,
-}
-
 #[starknet::interface]
 trait INostraPair<TContractState> {
     fn token_0(self: @TContractState) -> ContractAddress;

--- a/tests/test_treasury.cairo
+++ b/tests/test_treasury.cairo
@@ -15,12 +15,13 @@ use core::traits::{TryInto, Into};
 use core::byte_array::ByteArray;
 use array::ArrayTrait;
 use debug::PrintTrait;
-use starknet::{ContractAddress, get_block_number, ClassHash};
+use starknet::{ContractAddress, get_block_number, ClassHash, contract_address_const};
 use snforge_std::{
     BlockId, declare, ContractClassTrait, ContractClass, prank, CheatSpan, CheatTarget, roll
 };
 use konoha::treasury::{ITreasuryDispatcher, ITreasuryDispatcherTrait};
 use konoha::treasury_types::carmine::{IAMMDispatcher, IAMMDispatcherTrait};
+use konoha::treasury_types::nostra::{NostraPair, INostraPairDispatcher, INostraPairDispatcherTrait};
 use konoha::traits::{IERC20Dispatcher, IERC20DispatcherTrait};
 use openzeppelin::access::ownable::interface::{
     IOwnableTwoStep, IOwnableTwoStepDispatcherTrait, IOwnableTwoStepDispatcher
@@ -248,6 +249,72 @@ fn test_deposit_withdraw_carmine() {
     assert(
         transfer_dispatcher.balanceOf(treasury_contract_address) >= to_deposit, 'balance too low??'
     );
+}
+
+#[test]
+#[fork("MAINNET")]
+fn test_deposit_withdraw_nostra() {
+    let (gov_contract_address, _AMM_contract_address, treasury_contract_address) =
+        get_important_addresses();
+    let treasury_dispatcher = ITreasuryDispatcher { contract_address: treasury_contract_address };
+    // random whale
+    let sequencer_address =
+        contract_address_const::<0x01176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8>();
+    let router_address = treasury_dispatcher.get_nostra_router_address();
+    let pair_address = treasury_dispatcher.get_nostra_pair_address(NostraPair::STRK_ETH);
+    let pair = INostraPairDispatcher { contract_address: pair_address };
+    let token_0_address = pair.token_0();
+    let token_0 = IERC20Dispatcher { contract_address: token_0_address };
+    let token_1_address = pair.token_1();
+    let token_1 = IERC20Dispatcher { contract_address: token_1_address };
+    // transfer pair liquidity to treasury
+    prank(CheatTarget::One(token_0_address), sequencer_address, CheatSpan::TargetCalls(1));
+    token_0.transfer(treasury_contract_address, 4000000000000000000000);
+    prank(CheatTarget::One(token_1_address), sequencer_address, CheatSpan::TargetCalls(1));
+    token_1.transfer(treasury_contract_address,    1000000000000000000);
+    //
+    let token_0_initial_balance = token_0.balanceOf(treasury_contract_address);
+    let token_1_initial_balance = token_1.balanceOf(treasury_contract_address);
+    //
+    let amount_0_desired: u256 = 3000000000000000000000;
+    let amount_1_desired: u256 = 900000000000000000;
+    // test deposit
+    prank(CheatTarget::One(token_0_address), treasury_contract_address, CheatSpan::TargetCalls(1));
+    token_0.approve(router_address, token_0_initial_balance);
+    prank(CheatTarget::One(token_1_address), treasury_contract_address, CheatSpan::TargetCalls(1));
+    token_1.approve(router_address, token_1_initial_balance);
+    prank(
+        CheatTarget::One(treasury_contract_address), gov_contract_address, CheatSpan::TargetCalls(1)
+    );
+    let (amount_0_added, amount_1_added, amount_lp) = treasury_dispatcher.add_liquidity_to_nostra(
+        NostraPair::STRK_ETH,
+        amount_0_desired,
+        amount_1_desired,
+        1,
+        1,
+    );
+    let token_0_intermediate_balance = token_0.balanceOf(treasury_contract_address);
+    assert_eq!(amount_0_added, token_0_initial_balance - token_0_intermediate_balance);
+    let token_1_intermediate_balance = token_1.balanceOf(treasury_contract_address);
+    assert_eq!(amount_1_added, token_1_initial_balance - token_1_intermediate_balance);
+    let lp_balance = pair.balance_of(treasury_contract_address);
+    assert_eq!(amount_lp, lp_balance);
+    // test withdraw
+    prank(CheatTarget::One(pair_address), treasury_contract_address, CheatSpan::TargetCalls(1));
+    pair.approve(router_address, lp_balance);
+    prank(
+        CheatTarget::One(treasury_contract_address), gov_contract_address, CheatSpan::TargetCalls(1)
+    );
+    let (amount_0_removed, amount_1_removed) = treasury_dispatcher.remove_liquidity_from_nostra(
+        NostraPair::STRK_ETH,
+        lp_balance,
+        1,
+        1,
+    );
+    let token_0_final_balance = token_0.balanceOf(treasury_contract_address);
+    assert_eq!(amount_0_removed, token_0_final_balance - token_0_intermediate_balance);
+    let token_1_final_balance = token_1.balanceOf(treasury_contract_address);
+    assert_eq!(amount_1_removed, token_1_final_balance - token_1_intermediate_balance);
 }
 
 #[test]


### PR DESCRIPTION
This PR introduces the possibility for the treasury to deposit/withdraw liquidity on Nostra Pools.
The feature has been tested but lacks 100% coverage at the moment.

Still needs some polishing (more tests, events, etc.), will finish it ASAP.