### PR TITLE
Feature/get appliable proposals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      MAINNET_NODE_URL: ${{ secrets.MAINNET_NODE_URL }}
+      SEPOLIA_NODE_URL: ${{ secrets.SEPOLIA_NODE_URL }}
     steps:
       - name: Checkout (GitHub)
         uses: actions/checkout@v3

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -23,12 +23,12 @@ sort-module-level-items = true
 
 [[tool.snforge.fork]]
 name = "MAINNET"
-url = "https://starknet-mainnet.public.blastapi.io/rpc/v0_7"
+url = "$MAINNET_NODE_URL"
 block_id.tag = "Latest"
 
 [[tool.snforge.fork]]
 name = "SEPOLIA"
-url = "https://starknet-mainnet.public.blastapi.io/rpc/v0_7"
+url = "$SEPOLIA_NODE_URL"
 block_id.tag = "Latest"
 
 RUST_BACKTRACE = 1

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -23,12 +23,12 @@ sort-module-level-items = true
 
 [[tool.snforge.fork]]
 name = "MAINNET"
-url = "http://178.32.172.148:6060/v0_7"
+url = "https://starknet-mainnet.public.blastapi.io/rpc/v0_7"
 block_id.tag = "Latest"
 
 [[tool.snforge.fork]]
 name = "SEPOLIA"
-url = "http://178.32.172.148:6062/v0_7"
+url = "https://starknet-mainnet.public.blastapi.io/rpc/v0_7"
 block_id.tag = "Latest"
 
 RUST_BACKTRACE = 1

--- a/src/contract.cairo
+++ b/src/contract.cairo
@@ -179,7 +179,10 @@ mod Governance {
             treasury_calldata.append(governance_address.into());
             treasury_calldata.append(0x1); // carmine amm addr
             treasury_calldata.append(0x1); // zklend addr
-            treasury_calldata.append(0x027994c503bd8C32525FBDAf9d398bDd4e86757988C64581B055A06c5955eA49); // first guardian
+            treasury_calldata
+                .append(
+                    0x027994c503bd8C32525FBDAf9d398bDd4e86757988C64581B055A06c5955eA49
+                ); // first guardian
             let (treasury_address, _) = deploy_syscall(
                 treasury_classhash, 42, treasury_calldata.span(), false
             )
@@ -203,7 +206,8 @@ mod Governance {
 
             proposals.add_custom_proposal_config(add_guardian_custom_proposal_config);
 
-            let remove_guardian_custom_proposal_config: CustomProposalConfig = CustomProposalConfig {
+            let remove_guardian_custom_proposal_config: CustomProposalConfig =
+                CustomProposalConfig {
                 target: treasury_address.into(),
                 selector: selector!("remove_guardian"),
                 library_call: false,
@@ -229,8 +233,20 @@ mod Governance {
         let period = 21600; // 6 hours
         let increments_count = 56;
         let total_amount = 56000000000000000000; // 56 * 10**18 meaning 56 KONOHA tokens
-        vesting.add_linear_vesting_schedule(first_vest, period, increments_count, total_amount, 0x027994c503bd8C32525FBDAf9d398bDd4e86757988C64581B055A06c5955eA49.try_into().unwrap());
-        vesting.add_linear_vesting_schedule(first_vest, period, increments_count, total_amount, recipient);
+        vesting
+            .add_linear_vesting_schedule(
+                first_vest,
+                period,
+                increments_count,
+                total_amount,
+                0x027994c503bd8C32525FBDAf9d398bDd4e86757988C64581B055A06c5955eA49
+                    .try_into()
+                    .unwrap()
+            );
+        vesting
+            .add_linear_vesting_schedule(
+                first_vest, period, increments_count, total_amount, recipient
+            );
 
         proposals
             .set_default_proposal_params(

--- a/src/proposals.cairo
+++ b/src/proposals.cairo
@@ -270,8 +270,7 @@ mod proposals {
         fn _find_free_custom_proposal_type(self: @ComponentState<TContractState>) -> u32 {
             let mut i = 0;
             let mut res = self.custom_proposal_type.read(i);
-            while(res.target.is_non_zero())
-            {
+            while (res.target.is_non_zero()) {
                 i += 1;
                 res = self.custom_proposal_type.read(i);
             };

--- a/tests/deploy.cairo
+++ b/tests/deploy.cairo
@@ -6,8 +6,8 @@ use snforge_std::{
 
 //useful for debugging
 
-#[test]
-#[fork("SEPOLIA")]
+//#[test]
+//#[fork("SEPOLIA")]
 fn test_deploy() {
     let gov_contract = declare("Governance").expect('unable to declare governance');
     let treasury_class = 0x035ef05673259eca09f55fce176a195d110bdbc6b145c08811d0e252ea8adadb;

--- a/tests/proposals_tests.cairo
+++ b/tests/proposals_tests.cairo
@@ -626,7 +626,7 @@ fn test_get_appliable_proposals() {
     upgrades_dispatcher.apply_passed_proposal(prop_id_2);
 
     // should be only proposal 1
-    let appliable_proposals_after = dispatcher.get_appliable_proposals();
+    let mut appliable_proposals_after = dispatcher.get_appliable_proposals();
     assert!(appliable_proposals_after.len() == 1, "more than 1 appliable proposal!");
 
     assert!(

--- a/tests/proposals_tests.cairo
+++ b/tests/proposals_tests.cairo
@@ -597,9 +597,9 @@ fn test_get_appliable_proposals() {
     start_prank(CheatTarget::One(gov_contract_addr), admin_addr.try_into().unwrap());
 
     // create proposals 1, 2, 3
-    let prop_id_1: u128 = dispatcher.submit_proposal(123, 4).try_into().unwrap();
-    let prop_id_2: u128 = dispatcher.submit_proposal(124, 4).try_into().unwrap();
-    let prop_id_3: u128 = dispatcher.submit_proposal(125, 4).try_into().unwrap();
+    let prop_id_1 = dispatcher.submit_proposal(123, 4);
+    let prop_id_2 = dispatcher.submit_proposal(124, 4);
+    let prop_id_3 = dispatcher.submit_proposal(125, 4);
 
     // vote on proposals 1, 2
     dispatcher.vote(prop_id_1, 1);

--- a/tests/test_treasury.cairo
+++ b/tests/test_treasury.cairo
@@ -20,7 +20,8 @@ use openzeppelin::access::ownable::interface::{
 };
 use openzeppelin::upgrades::interface::{IUpgradeableDispatcher, IUpgradeableDispatcherTrait};
 use snforge_std::{
-    BlockId, declare, get_class_hash, ContractClassTrait, ContractClass, prank, CheatSpan, CheatTarget, roll, warp
+    BlockId, declare, get_class_hash, ContractClassTrait, ContractClass, prank, CheatSpan,
+    CheatTarget, roll, warp
 };
 use starknet::{ContractAddress, get_block_number, get_block_timestamp, ClassHash};
 mod testStorage {
@@ -69,7 +70,11 @@ fn get_important_addresses() -> (
         },
         // FIXME – this is suboptimal, but afaik no way to get this in current snforge version?
         Result::Err(_) => { // already declared. we should 'only' deploy //0x04c990da03da72bdfb10db5c04e8aaa9d5404a07fe454037facb7744c132d42c.try_into().unwrap()
-            let r = ContractClass { class_hash: 0x035ef05673259eca09f55fce176a195d110bdbc6b145c08811d0e252ea8adadb.try_into().unwrap()};
+            let r = ContractClass {
+                class_hash: 0x035ef05673259eca09f55fce176a195d110bdbc6b145c08811d0e252ea8adadb
+                    .try_into()
+                    .unwrap()
+            };
             let contract_address = r.precalculate_address(@calldata);
             prank(
                 CheatTarget::One(contract_address), gov_contract_address, CheatSpan::TargetCalls(1)
@@ -874,11 +879,12 @@ fn test_deposit_withdraw_carmine() {
 
     let transfer_dispatcher = IERC20Dispatcher { contract_address: eth_addr };
     prank(CheatTarget::One(eth_addr), sequencer_address, CheatSpan::TargetCalls(2));
-    let oneeth =    1000000000000000000;
+    let oneeth = 1000000000000000000;
     let to_deposit = 900000000000000000;
     transfer_dispatcher.transfer(treasury_contract_address, oneeth);
     assert(
-       transfer_dispatcher.balanceOf(treasury_contract_address) >= to_deposit, 'balance after tx too low??'
+        transfer_dispatcher.balanceOf(treasury_contract_address) >= to_deposit,
+        'balance after tx too low??'
     );
     prank(
         CheatTarget::One(treasury_contract_address), gov_contract_address, CheatSpan::TargetCalls(1)
@@ -899,10 +905,7 @@ fn test_deposit_withdraw_carmine() {
     roll(
         CheatTarget::All, get_block_number() + 1, CheatSpan::Indefinite
     ); // to bypass sandwich guard
-    treasury_dispatcher
-        .withdraw_liquidity(
-            eth_addr, usdc_addr, eth_addr, 0, to_deposit.into()
-        );
+    treasury_dispatcher.withdraw_liquidity(eth_addr, usdc_addr, eth_addr, 0, to_deposit.into());
     assert(
         transfer_dispatcher.balanceOf(treasury_contract_address) >= to_deposit, 'balance too low??'
     );


### PR DESCRIPTION
- adds view function `get_appliable_proposals`, which returns ids of proposals that have passed and are not yet applied
- uses RPC url from env vars to prevent exposure of private node's url